### PR TITLE
NEW Adds currency conversion to Balance Report

### DIFF
--- a/currencies/money.py
+++ b/currencies/money.py
@@ -64,6 +64,9 @@ class MoneyAggregator:
     def get_moneys(self) -> List[Money]:
         return copy(self._moneys)
 
+    def as_balance(self) -> Balance:
+        return Balance(self.get_moneys())
+
 
 @attr.s(frozen=True, cmp=False)
 class Balance:

--- a/reports/serializers.py
+++ b/reports/serializers.py
@@ -149,6 +149,13 @@ class BalanceEvolutionOutputSerializer(serializers.Serializer):
 class BalanceEvolutionInputSerializer(serializers.Serializer):
     accounts = _new_account_list_serializer()
     dates = serializers.ListSerializer(child=serializers.DateField())
+    currency_opts = CurrencyOptsSerializer(default=None)
 
     def create(self, data):
-        return BalanceEvolutionInput(accounts=data['accounts'], dates=data['dates'])
+        created_data = {'accounts': data['accounts'], 'dates': data['dates']}
+        if data['currency_opts'] is not None:
+            created_data['currency_opts'] = self._create_currency_opts(data)
+        return BalanceEvolutionInput(**created_data)
+
+    def _create_currency_opts(self, data):
+        return self.fields['currency_opts'].create(data['currency_opts'])

--- a/reports/tests/test_reports_view_models.py
+++ b/reports/tests/test_reports_view_models.py
@@ -1,0 +1,48 @@
+import datetime
+from decimal import Decimal
+from unittest.mock import Mock
+
+from common.test import PacsTestCase
+from currencies.currency_converter import CurrencyPricePortifolio, DateAndPrice
+from currencies.money import Money
+from currencies.tests.factories import CurrencyTestFactory
+from reports.view_models import CurrencyOpts, BalanceEvolutionInput
+
+
+class TestCurrencyOptsAsCurrencyConversionFn(PacsTestCase):
+
+    def test_base(self):
+        date = datetime.date(2019, 1, 1)
+        convert_from = CurrencyTestFactory(code="BRL")
+        convert_to = CurrencyTestFactory(code="USD")
+        price_portifolio = [
+            CurrencyPricePortifolio(
+                currency=convert_from,
+                prices=[DateAndPrice(date=date, price=Decimal('0.25'))],
+            ),
+            CurrencyPricePortifolio(
+                currency=convert_to,
+                prices=[DateAndPrice(date=date, price=1)],
+            ),
+        ]
+        currency_opts = CurrencyOpts(price_portifolio, convert_to)
+        conversion_fn = currency_opts.as_currency_conversion_fn()
+        exp = Money(Decimal(1), convert_to)
+        res = conversion_fn(Money(Decimal(4), convert_from), date)
+        assert res == exp
+
+
+class TestBalanceEvolutionInputAsDict:
+
+    def test_no_currency_opts(self):
+        args = {"accounts": Mock(), "dates": Mock()}
+        input_ = BalanceEvolutionInput(**args)
+        assert input_.as_dict() == args
+
+    def test_with_currency_opts(self):
+        args = {"accounts": Mock(), "dates": Mock(), "currency_opts": Mock()}
+        input_ = BalanceEvolutionInput(**args)
+        resp = input_.as_dict()
+        assert resp['currency_conversion_fn'] == (
+            args['currency_opts'].as_currency_conversion_fn()
+        )

--- a/reports/views.py
+++ b/reports/views.py
@@ -29,7 +29,7 @@ class BalanceEvolutionViewSpec:
 
     @classmethod
     def _gen_report(cls, inputs: BalanceEvolutionInput) -> BalanceEvolutionReport:
-        return BalanceEvolutionQuery(**attr.asdict(inputs)).run()
+        return BalanceEvolutionQuery(**inputs.as_dict()).run()
 
     @classmethod
     def post(cls, request):


### PR DESCRIPTION
Adds `currency_conversion_fn` argument to `BalanceEvolutionQuery`
which is used to convert a `Money` from one currency to another at a
specific date.

Parses `currency_conversion_fn` from the user inputted `currency_opts`
during serialization/input parsing for the balance report view.

Optionally, splits the `_run` method of BalanceEvolutionQuery into
three parts.